### PR TITLE
Add argparser, kindle scribe support, year, line widh/color arguments

### DIFF
--- a/make-calendar
+++ b/make-calendar
@@ -1,9 +1,34 @@
 #!/usr/bin/python3
 from fpdf import FPDF
 import datetime
+import argparse
+
+parser = argparse.ArgumentParser(description='Calendar Generator')
+parser.add_argument('-y','--year', help='Year to generate', required=False)
+parser.add_argument('-lw','--linewidth', help='Width of time block lines (0 default)', required=False)
+parser.add_argument('-lc','--linecolor', help='color of time block lines (200 default - higher is lighter)', required=False)
+parser.add_argument('-f','--format', help='Out output format [None, Scribe]', required=False)
+args = vars(parser.parse_args())
 
 font = 'Arial'
 year = 2025
+if args['year']:
+	year = int(args['year'])
+	
+print( f"Generating calendar for {year}" )
+
+time_block_line_width = 0
+time_block_line_color = 200
+if args['linewidth']:
+	time_block_line_width = float(args['linewidth'])
+if args['linecolor']:
+	time_block_line_color = int(args['linecolor'])
+
+scribe_format = False
+if args['format'] and args['format'].lower() == "scribe":
+	scribe_format = True
+	time_block_line_width = 0.25
+	time_block_line_color = 160
 
 # close to a4 sizes in mm, but matching the remarkable 2
 w = 210
@@ -19,6 +44,7 @@ pdf = FPDF(
 )
 pdf.set_margins(0,0)
 pdf.set_auto_page_break(False)
+pdf.set_author( "Trammell Hudson" )
 
 links = {}
 days = [ "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun" ]
@@ -43,7 +69,7 @@ def add_calendar(
 	x,
 	y,
 	day_font = None,
-	border=False,
+	border = False,
 	include_year = False,
 	ysize = None,
 ):
@@ -170,8 +196,8 @@ def add_day(pdf, year, mon, day):
 	)
 
 	# add the time blocks
-	pdf.set_draw_color(200)
-	pdf.set_line_width(0)
+	pdf.set_draw_color(time_block_line_color)
+	pdf.set_line_width(time_block_line_width)
 	pdf.set_text_color(40)
 	pdf.set_font(font, 'B', 16)
 


### PR DESCRIPTION
Added argparser and the ability to specify the year, linewidth, linecolor, and format arguments ("scribe" selects defaults for linewidth and line color that work well on the Kindle Scribe)

Also added author field to PDF designating Trammell Husdon as the author

Feel free to tidy up as necessary.